### PR TITLE
Add support for ``zope.sqlalchemy >= 1.3``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,21 @@
 Change log for risclog.sqlalchemy
 =================================
 
-3.1 (unreleased)
+4.0 (unreleased)
 ================
 
-- Add support for Python 3.7.
+Backward incompatible changes
+-----------------------------
+
+- Add support for ``zope.sqlalchemy >= 1.3`` by requiring at least this version.
+  (Older versions only supported ``zope.sqlalchemy <= 1.2``.)
 
 - Drop support for PyPy, PyPy3, Python 3.4 and 3.5.
+
+Other changes
+-------------
+
+- Add support for Python 3.7.
 
 - Migrate to Github.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import glob
 
 setup(
     name='risclog.sqlalchemy',
-    version='3.1.dev0',
+    version='4.0.dev0',
 
     install_requires=[
         'SQLAlchemy >= 1.0',
@@ -18,7 +18,7 @@ setup(
         'setuptools',
         'zope.component >= 4.0.1, <= 4.4.1',
         'zope.interface',
-        'zope.sqlalchemy < 1.2',
+        'zope.sqlalchemy >= 1.3',
     ],
 
     extras_require={

--- a/src/risclog/sqlalchemy/db.py
+++ b/src/risclog/sqlalchemy/db.py
@@ -92,10 +92,9 @@ class Database(object):
         self._engines = {}
         self.testing = testing
         self.session_factory = sqlalchemy.orm.scoped_session(
-            sqlalchemy.orm.sessionmaker(
-                class_=RoutingSession,
-                extension=zope.sqlalchemy.ZopeTransactionExtension(
-                    keep_session=testing)))
+            sqlalchemy.orm.sessionmaker(class_=RoutingSession))
+        self.zope_transaction_events = zope.sqlalchemy.register(
+            self.session_factory, keep_session=testing)
         self._setup_utility()
 
     def register_engine(self, dsn, engine_args={}, name=_BLANK,

--- a/src/risclog/sqlalchemy/fixtures.py
+++ b/src/risclog/sqlalchemy/fixtures.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.fixture(scope='function')
-def database__selenium_testing(request):
+def database__selenium_testing():
     """Prepare the database for selenium testing:
 
     Remove the SQLAlchemy session after transaction.commit(). This is the same
@@ -11,11 +11,8 @@ def database__selenium_testing(request):
     tests.
     """
     db = risclog.sqlalchemy.db.get_database(testing=True)
-    extension = db.session_factory.session_factory.kw['extension']
-    old_keep_session = extension.keep_session
-    extension.keep_session = False
+    old_keep_session = db.zope_transaction_events.keep_session
+    db.zope_transaction_events.keep_session = False
 
-    def finalizer():
-        extension.keep_session = old_keep_session
-
-    request.addfinalizer(finalizer)
+    yield
+    db.zope_transaction_events.keep_session = old_keep_session


### PR DESCRIPTION
This means that we require at least this version.

Fixes #2.