### PR TITLE
Require SQLAlchemy < 2.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       hooks:
           - id: autopep8
     - repo: https://github.com/PyCQA/isort
-      rev: 5.11.4
+      rev: 5.12.0
       hooks:
       - id: isort
         args: [--filter-files]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Change log for risclog.sqlalchemy
 
 - Add support for Python 3.10 and 3.11.
 
+- Restrict supported SQLALchemy to < 2.
+
 
 5.1 (2021-04-28)
 ================

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     version='6.0.dev0',
     python_requires='>=3.7',
     install_requires=[
-        'SQLAlchemy >= 1.0',
+        'SQLAlchemy >= 1.0, < 2',
         'alembic >= 0.7',
         'pytz',
         'setuptools',


### PR DESCRIPTION
Changes are required to get it running.

This change should make GHA green again.

See also #39.